### PR TITLE
Updated SDK to version 3.

### DIFF
--- a/external_checks_scripts/Gemfile
+++ b/external_checks_scripts/Gemfile
@@ -1,6 +1,3 @@
 source "https://rubygems.org"
-gem 'aws-sdk', '>=2.6.42'
-gem 'aws-sdk-core', '>=2.4.42'
-gem 'aws-sdk-resources', '>=2.4.42'
-gem 'aws-sdk-v1', '>=1.66.0'
-gem 'zabbixapi', '>=3.1.0'
+gem 'aws-sdk', '~> 3'
+gem 'zabbixapi', '>=3.2.0'

--- a/external_checks_scripts/as_group_activity.rb
+++ b/external_checks_scripts/as_group_activity.rb
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 
-require 'aws-sdk-core'
+require 'aws-sdk'
 require 'net/http'
 
 unless ARGV.size > 1

--- a/external_checks_scripts/cw_log_filter.rb
+++ b/external_checks_scripts/cw_log_filter.rb
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 
-require 'aws-sdk-core'
+require 'aws-sdk'
 require 'net/http'
 
 if ARGV.size < 3

--- a/external_checks_scripts/get_metric_statistics.rb
+++ b/external_checks_scripts/get_metric_statistics.rb
@@ -18,24 +18,21 @@ period = ARGV[7] || '300'
 
 cs = Aws::CloudWatch::Client.new(region: region)
 
-cw.put_metric_data({
+metrics = Aws::CloudWatch::Metric({
+  client: cs,
   namespace: namespace,
-  metric_data: [{
-    metric_name: metric_name,
-    dimensions: [
-      {
-        name: dime_name,
-	value: dime_value
-      }
-    ]
-  }]
+  name: metric_name
 })
 
 stats = metrics.get_statistics({
   start_time: Time.now - diff_time.to_i,
   end_time: Time.now,
   statistics: [statistics_type],
-  period: period.to_i
+  period: period.to_i,
+  dimensions: [{
+    name: dime_name,
+    value: dime_value 
+  }]
 })
 
 last_stats = stats.datapoints.sort_by { |stat| stat[:timestamp] }.last

--- a/external_checks_scripts/get_metric_statistics.rb
+++ b/external_checks_scripts/get_metric_statistics.rb
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 
-require 'aws-sdk-v1'
+require 'aws-sdk'
 
 if ARGV.size < 6
   puts "Usage: #{$PROGRAM_NAME} [REGION] [NAMESPACE] [METRIC_NAME] [DIMENTION_NAME] [DIMENTION_VALUE] [STATISTICS_TYPE](Average) [DIFFERENCE_TIME(sec)](600) [PERIOD(sec)](300)"
@@ -16,26 +16,29 @@ statistics_type = ARGV[5] || 'Average'
 diff_time = ARGV[6] || '600'
 period = ARGV[7] || '300'
 
-AWS.config(
-  region: region
-)
+cs = Aws::CloudWatch::Client.new(region: region)
 
-metrics = AWS::CloudWatch::Metric.new(
-  namespace,
-  metric_name,
-  dimensions: [
-    { name: dime_name, value: dime_value }
-  ]
-)
+cw.put_metric_data({
+  namespace: namespace,
+  metric_data: [{
+    metric_name: metric_name,
+    dimensions: [
+      {
+        name: dime_name,
+	value: dime_value
+      }
+    ]
+  }]
+})
 
-stats = metrics.statistics(
+stats = metrics.get_statistics({
   start_time: Time.now - diff_time.to_i,
   end_time: Time.now,
   statistics: [statistics_type],
   period: period.to_i
-)
+})
 
-last_stats = stats.sort_by { |stat| stat[:timestamp] }.last
+last_stats = stats.datapoints.sort_by { |stat| stat[:timestamp] }.last
 if last_stats.nil?
   puts 0
 else

--- a/external_checks_scripts/rds_event_check.rb
+++ b/external_checks_scripts/rds_event_check.rb
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 
-require 'aws-sdk-v1'
+require 'aws-sdk'
 require 'net/http'
 
 if ARGV.size < 3
@@ -17,15 +17,15 @@ metadata_endpoint = 'http://169.254.169.254/latest/meta-data/'
 local_hostname = Net::HTTP.get(URI.parse(metadata_endpoint + '/local-hostname'))
 region = local_hostname.split('.')[1]
 
-rds = AWS::RDS::Client.new(region: region)
+rds = AWS::RDS::Resource.new(region: region)
 
-events = rds.describe_events(
+events = rds.events(
   start_time: (Time.now - diff_time.to_i).iso8601,
   end_time: Time.now.iso8601,
   source_type: 'db-instance',
   event_categories: [event_cat],
   source_identifier: source_id
-)[:events]
+)
 
 last_event = events.sort_by { |event| event[:date] }.last
 if last_event.nil?
@@ -33,3 +33,4 @@ if last_event.nil?
 else
   puts last_event[:message]
 end
+/bin/bash: pbpaste: command not found


### PR DESCRIPTION
Updated SDK to version 3.

Updates from Version 2 to 3, followed AWS Documentation at https://aws.amazon.com/blogs/developer/upgrading-from-version-2-to-version-3-of-the-aws-sdk-for-ruby-2/

Updates from Version 1 to 3, worked through API Documentation to find comparable calls.

Summary & Rationale of Changes by file:
**Gemfile**
  - SDK version 3 no longer requires the declaration of core, resources, etc.   

**as_group_activity.rb**
  - Updated includes only

**cw_log_filter.rb**
  - Updated includes only

**get_metric_statistics.rb**
  - Updated includes
  - swapped AWS.config & AWS::CloudWatch::Metric calls for Aws:CloudWatch::Client.
  - Move dimension to get_statistics call

**rds_event_check.rb**
  - Updated includes
  - swapped RDS::Client to RDS::Resource
  - updated method call name



